### PR TITLE
Allow saving and loading of box positions and dimensions

### DIFF
--- a/dogfood/logo-markup/pages/video/[videoId].tsx
+++ b/dogfood/logo-markup/pages/video/[videoId].tsx
@@ -10,6 +10,8 @@ import dynamic from "next/dynamic";
 import {
   Box,
   Button,
+  Grid,
+  GridItem,
   Heading,
   Slider,
   SliderFilledTrack,
@@ -467,6 +469,80 @@ export default function VideoPage(props: VideoPageProps) {
               >
                 Mark complete and save
               </Button>
+              <Heading as="h3" size="md">Load box position/dimensions for selected box</Heading>
+              <Grid templateColumns='repeat(10, 1fr)' gap={1}>
+                {Array.from(Array(10).keys()).map((key, i) => (
+                  <GridItem key={i} w="10%">
+                    <Button
+                      onClick={() => {
+                        if (selectedAction === null) {
+                          toast({
+                            title: "Error",
+                            description: "Select a box before saving",
+                            status: "error",
+                            duration: 4000,
+                            isClosable: true,
+                          });
+                          return;
+                        };
+                        if (localStorage.getItem(`saved-box-dimensions-${i}`) === null) {
+                          toast({
+                            title: "Error",
+                            description: "No dimensions are saved on this slot",
+                            status: "error",
+                            duration: 4000,
+                            isClosable: true,
+                          });
+                          return;
+                        }
+                        const selectedBoxIndex = data[0].actions.findIndex((action) => action.id === selectedShape ||
+                          action.id === selectedAction?.id)
+                        const actions = [...data[0].actions];
+                        const attrs = JSON.parse(localStorage.getItem(`saved-box-dimensions-${i}`) || "");
+                        const newActionObj = {
+                          ...actions[selectedBoxIndex],
+                          ...attrs,
+                        };
+                        actions[selectedBoxIndex] = newActionObj;
+                        setData([{ id: "0", actions }]);
+                      }}
+                    >
+                      {++i}
+                    </Button>
+                  </GridItem>
+                ))}
+              </Grid>
+              <Heading as="h3" size="md">Save selected box position/dimensions</Heading>
+              <Grid templateColumns='repeat(10, 1fr)' gap={1}>
+                {Array.from(Array(10).keys()).map((key, i) => (
+                  <GridItem key={i} w="10%">
+                    <Button
+                      onClick={() => {
+                        if (selectedAction === null) {
+                          toast({
+                            title: "Error",
+                            description: "Select a box before loading",
+                            status: "error",
+                            duration: 4000,
+                            isClosable: true,
+                          });
+                          return;
+                        };
+                        const selectedBox = data[0].actions.filter((action) => action.id === selectedShape ||
+                          action.id === selectedAction?.id)
+                        localStorage.setItem(`saved-box-dimensions-${i}`, JSON.stringify({
+                          x: selectedBox[0].x,
+                          y: selectedBox[0].y,
+                          width: selectedBox[0].width,
+                          height: selectedBox[0].height
+                        }))
+                      }}
+                    >
+                      {++i}
+                    </Button>
+                  </GridItem>
+                ))}
+              </Grid>
             </>
           )}
         </Stack>


### PR DESCRIPTION
Added ability to save and load box positions and dimensions between videos to allow a faster workflow. The x and y positions and width and height values are stored and retrieved in localstorage. There are 10 slots right now for saving/loading.

I could not test saving because I did not have the environment variables for the database and such but whenever a user clicks on a load dimensions slot it will only update the selected box data state so saving should work as expected, but you are welcome to confirm this before merging.

Let me know what you think.

![image](https://github.com/katsukixyz/izone-archive/assets/95774730/3ae953ae-0da4-44a9-9fed-8096bd0bd084)